### PR TITLE
verbose message to increase size_embeddings_count

### DIFF
--- a/jerex/data_module.py
+++ b/jerex/data_module.py
@@ -19,7 +19,8 @@ class DocREDDataModule(pl.LightningDataModule):
                  sampling_processes: int = 4, neg_mention_count: int = 50,
                  neg_relation_count: int = 50, neg_coref_count: int = 50,
                  max_span_size: int = 10, neg_mention_overlap_ratio: float = 0.5,
-                 final_valid_evaluate: bool = False):
+                 final_valid_evaluate: bool = False,
+                 size_embeddings_count: int = 30):
         super().__init__()
 
         if types_path is not None:
@@ -56,6 +57,7 @@ class DocREDDataModule(pl.LightningDataModule):
         self._neg_coref_count = neg_coref_count
         self._max_span_size = max_span_size
         self._neg_mention_overlap_ratio = neg_mention_overlap_ratio
+        self._size_embeddings_count = size_embeddings_count
 
         self._train_path = train_path
         self._valid_path = valid_path
@@ -81,7 +83,8 @@ class DocREDDataModule(pl.LightningDataModule):
                                                     neg_rel_count=self._neg_relation_count,
                                                     max_span_size=self._max_span_size,
                                                     neg_mention_overlap_ratio=self._neg_mention_overlap_ratio,
-                                                    tokenizer=self._tokenizer)
+                                                    tokenizer=self._tokenizer,
+                                                    size_embeddings_count=self._size_embeddings_count)
 
                 self._train_dataset.switch_task(self._task_type)
                 self._train_dataset.switch_mode(DocREDDataset.TRAIN_MODE)
@@ -91,7 +94,8 @@ class DocREDDataModule(pl.LightningDataModule):
                                                     entity_types=self._entity_types,
                                                     relation_types=self._relation_types,
                                                     max_span_size=self._max_span_size,
-                                                    tokenizer=self._tokenizer)
+                                                    tokenizer=self._tokenizer,
+                                                    size_embeddings_count=self._size_embeddings_count)
 
                 self._valid_dataset.switch_task(self._task_type)
                 self._valid_dataset.switch_mode(DocREDDataset.INFERENCE_MODE)
@@ -104,7 +108,8 @@ class DocREDDataModule(pl.LightningDataModule):
                                                    entity_types=self._entity_types,
                                                    relation_types=self._relation_types,
                                                    max_span_size=self._max_span_size,
-                                                   tokenizer=self._tokenizer)
+                                                   tokenizer=self._tokenizer,
+                                                   size_embeddings_count=self._size_embeddings_count)
             else:
                 self._test_dataset = self._valid_dataset
 
@@ -112,7 +117,7 @@ class DocREDDataModule(pl.LightningDataModule):
             self._test_dataset.switch_mode(DocREDDataset.INFERENCE_MODE)
 
     def train_dataloader(self):
-        return DataLoader(self._train_dataset, batch_size=self._train_batch_size, shuffle=True, drop_last=True,
+        return DataLoader(self._train_dataset, batch_size=self._train_batch_size, shuffle=False, drop_last=True,
                           num_workers=self._sampling_processes,
                           collate_fn=collate_fn_padding)
 

--- a/jerex/datasets.py
+++ b/jerex/datasets.py
@@ -19,7 +19,8 @@ class DocREDDataset(TorchDataset):
     INFERENCE_MODE = 'inference'
 
     def __init__(self, dataset_path, entity_types, relation_types, tokenizer, neg_mention_count=200,
-                 neg_rel_count=200, neg_coref_count=200, max_span_size=10, neg_mention_overlap_ratio=0.5):
+                 neg_rel_count=200, neg_coref_count=200, max_span_size=10, neg_mention_overlap_ratio=0.5,
+                 size_embeddings_count=30):
         self._dataset_path = dataset_path
         self._entity_types = entity_types
         self._relation_types = relation_types
@@ -29,6 +30,7 @@ class DocREDDataset(TorchDataset):
         self._max_span_size = max_span_size
         self._neg_mention_overlap_ratio = neg_mention_overlap_ratio
         self._tokenizer = tokenizer
+        self._size_embeddings_count = size_embeddings_count
 
         self._mode = DocREDDataset.TRAIN_MODE
         self._task = None
@@ -204,7 +206,8 @@ class DocREDDataset(TorchDataset):
                 return sampling_joint.create_joint_train_sample(doc, self._neg_mention_count, self._neg_rel_count,
                                                                 self._neg_coref_count,
                                                                 self._max_span_size, self._neg_mention_overlap_ratio,
-                                                                len(self._relation_types))
+                                                                len(self._relation_types),
+                                                                self._size_embeddings_count)
             elif self._task == TaskType.MENTION_LOCALIZATION:
                 return sampling_classify.create_mention_classify_train_sample(doc, self._neg_mention_count,
                                                                               self._max_span_size,

--- a/jerex/model.py
+++ b/jerex/model.py
@@ -286,7 +286,8 @@ def train(cfg: TrainConfig):
                                    max_span_size=cfg.sampling.max_span_size,
                                    neg_mention_overlap_ratio=cfg.sampling.neg_mention_overlap_ratio,
                                    final_valid_evaluate=cfg.misc.final_valid_evaluate
-                                                        and cfg.datasets.test_path is None)
+                                                        and cfg.datasets.test_path is None,
+                                    size_embeddings_count=cfg.model.size_embeddings_count)
 
     data_module.setup('fit')
 

--- a/jerex/sampling/sampling_joint.py
+++ b/jerex/sampling/sampling_joint.py
@@ -7,7 +7,8 @@ from jerex.sampling.sampling_common import create_mention_candidates, create_con
 
 
 def create_joint_train_sample(doc: Document, neg_mention_count: int, neg_rel_count: int, neg_coref_count: int,
-                              max_span_size: int, neg_mention_overlap_ratio: float, rel_type_count: int):
+                              max_span_size: int, neg_mention_overlap_ratio: float, rel_type_count: int,
+                              size_embeddings_count: int):
     encodings = doc.encodings  # document sub-word encoding
     context_size = len(encodings)
 
@@ -89,6 +90,7 @@ def create_joint_train_sample(doc: Document, neg_mention_count: int, neg_rel_cou
     assert len(coref_mention_pairs) == len(coref_sample_masks) == len(coref_types) == len(coref_eds)
     assert len(entities) == len(entity_types)
     assert len(rel_entity_pairs) == len(rel_types)
+    assert mention_sizes.max().item() < size_embeddings_count, f"You should increase the `size_embeddings_count` config.model section atleast to {mention_sizes.max()}"
 
     return dict(encodings=encodings, context_masks=context_masks, mention_masks=mention_masks,
                 mention_sizes=mention_sizes, mention_types=mention_types, mention_sample_masks=mention_sample_masks,


### PR DESCRIPTION
Hi
First, thank you for the great effort, I learned a lot from you.  
I tried to use your model for my own dataset, but since the length of entity spans are a bit larger than the default `size_embeddings_count` in the config, I wasn't successful.  I was getting this error message, which wasn't clear enough.
```bash
IndexError: index out of range in self
``` 
It took me a whole day to dig the bug up, I tried to change your code to have a more verbose message about this issue.  
I hope it can help others with a similar problem.